### PR TITLE
feat: create task form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,37 @@
 import './App.css'
+import { useState } from 'react';
 
 import Header from './layouts/Header/Header';
 import MainContent from './layouts/MainContent/MainContent';
 import Footer from './layouts/Footer/Footer';
-import { initialTasks } from './data/initialTasks';
+
+import initialTasks from './data/initialTasks';
+import type { Task } from "./types/task";
 
 function App() {
+  const [tasks, setTasks] = useState<Task[]>(initialTasks);
+
+  const addTask = (title: string, content: string, deadline: string) => {
+    const newTask: Task = {
+      id: crypto.randomUUID(),
+      title,
+      content,
+      deadline,
+      completed: false,
+      createdAt: new Date().toISOString(),
+    };
+
+    setTasks((prevTasks) => [newTask, ...prevTasks]);
+  }
   
   return (
-    <>
+    <div className='app'>
       <Header />
-      <MainContent tasks={initialTasks}/>
+
+      <MainContent tasks={tasks} onAddTask={addTask} />
+
       <Footer />
-    </>
+    </div>
   )
 }
 

--- a/src/conponents/TaskForm/TaskForm.css
+++ b/src/conponents/TaskForm/TaskForm.css
@@ -1,0 +1,51 @@
+.task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  margin-bottom: 24px;
+  padding: 16px;
+
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background-color: #fafafa;
+}
+
+.task-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.task-form__field label {
+  font-weight: bold;
+  font-size: 14px;
+}
+
+.task-form__field input,
+.task-form__field textarea {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.task-form__field textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.task-form button {
+  align-self: flex-start;
+  padding: 8px 16px;
+
+  border: none;
+  border-radius: 6px;
+  background-color: #333;
+  color: white;
+  cursor: pointer;
+}
+
+.task-form button:hover {
+  opacity: 0.8;
+}

--- a/src/conponents/TaskForm/TaskForm.tsx
+++ b/src/conponents/TaskForm/TaskForm.tsx
@@ -1,0 +1,72 @@
+import "./TaskForm.css";
+import React, { useState } from "react";
+
+type TaskFormProps = {
+  onAddTask: (title: string, content: string, deadline: string) => void;
+}
+
+const TaskForm = ({ onAddTask }: TaskFormProps) => {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [deadline, setDeadline] = useState("");
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    // フォーム送信時にページがリロードされるのを防ぐ記述
+    // これがないと追加ボタンを押した瞬間にページが再読み込みされてstateがリセットされる
+    e.preventDefault();
+
+    // 空のタスク名を防ぐ記述
+    // trim()で前後の空白を消去し、それが空文字だった場合にreturnする。
+    if (title.trim() === "") {
+      return;
+    }
+
+    onAddTask(title, content, deadline);
+
+    // onAddTask後に各stateを初期化する記述
+    setTitle("");
+    setContent("");
+    setDeadline("");
+  };
+
+  return (
+    <form className="task-form" onSubmit={handleSubmit}>
+
+      <div className="task-form__field">
+        <label htmlFor="title">タスク名</label>
+        <input
+          id="title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="例：ReactのuseStateを復習する"
+        />
+      </div>
+
+      <div className="task-form__field">
+        <label htmlFor="context">内容</label>
+        <textarea
+          id="content"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="タスクの詳細を入力"
+        />
+      </div>
+
+      <div className="task-form__field">
+        <label htmlFor="deadline">期限</label>
+        <input 
+          id="deadline"
+          type="date"
+          value={deadline}
+          onChange={(e) => setDeadline(e.target.value)}
+        />
+      </div>
+
+      <button type="submit">追加</button>
+
+    </form>
+  )
+}
+
+export default TaskForm;

--- a/src/conponents/TaskList/TaskList.css
+++ b/src/conponents/TaskList/TaskList.css
@@ -1,5 +1,6 @@
 .task-list {
   width: 100%;
+  margin-bottom: 24px;
 }
 
 .task-list__title {

--- a/src/data/initialTasks.ts
+++ b/src/data/initialTasks.ts
@@ -1,6 +1,6 @@
 import type { Task } from "../types/task";
 
-export const initialTasks: Task[] = [
+const initialTasks: Task[] = [
   {
     id: "1",
     title: "Test Task",
@@ -26,3 +26,5 @@ export const initialTasks: Task[] = [
     createdAt: "2026-04-29T00:00:00.000Z",
   }
 ];
+
+export default initialTasks;

--- a/src/layouts/MainContent/MainContent.css
+++ b/src/layouts/MainContent/MainContent.css
@@ -2,7 +2,7 @@
   height: 75vh;
   padding: 24px;
   box-sizing: border-box;
-  background-color: #ffffff;
+  background-color: #CEE6C1;
 
   overflow-y: auto;
 }

--- a/src/layouts/MainContent/MainContent.tsx
+++ b/src/layouts/MainContent/MainContent.tsx
@@ -2,16 +2,19 @@ import "./MainContent.css";
 
 import type { Task } from "../../types/task";
 import TaskList from "../../conponents/TaskList/TaskList";
+import TaskForm from "../../conponents/TaskForm/TaskForm";
 
 type MainContentProps = {
   tasks: Task[];
-}
+  onAddTask: (title: string, content: string, deadline: string) => void;
+};
 
-const MainContent = ({ tasks }: MainContentProps) => {
+const MainContent = ({ tasks, onAddTask }: MainContentProps) => {
 
   return (
     <main className="main-content">
       <TaskList tasks={tasks}/>
+      <TaskForm onAddTask={onAddTask}/>
     </main>
   )
 };


### PR DESCRIPTION
## 概要
タスク追加用のフォームを作成した。

## 実装内容
- タスク入力フォームを作成
- 入力値をstateで管理
- 追加ボタンでタスク一覧に反映
- 空文字入力を防止

## 確認したこと
- タスク名を入力して追加できる
- 空文字では追加されない
- 追加後に入力欄が空になる
- TypeScriptエラーがない

close #6 