### PR TITLE
feat:add localstorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css'
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import Header from './layouts/Header/Header';
 import MainContent from './layouts/MainContent/MainContent';
@@ -7,9 +7,21 @@ import Footer from './layouts/Footer/Footer';
 
 import initialTasks from './data/initialTasks';
 import type { Task } from "./types/task";
+import {
+  loadTasksFromLocalStorage,
+  saveTasksToLocalStorage,
+} from "./utils/localStorage";
 
 function App() {
-  const [tasks, setTasks] = useState<Task[]>(initialTasks);
+  const [tasks, setTasks] = useState<Task[]>(() => {
+    const storeadTasks = loadTasksFromLocalStorage();
+
+    return storeadTasks ?? initialTasks;
+  });
+
+  useEffect(() => {
+    saveTasksToLocalStorage(tasks);
+  }, [tasks]);
 
   const addTask = (title: string, content: string, deadline: string) => {
     const newTask: Task = {
@@ -54,4 +66,4 @@ function App() {
   )
 }
 
-export default App
+export default App;

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,25 @@
+import type { Task } from "../types/task";
+
+const STORAGE_KEY = "study-task-manager-tasks";
+
+// 保存処理
+// LocalStorageには基本的に文字列しか保存できない
+// JSON.stringify()でタスク配列を文字列に変換して保存している
+export const saveTasksToLocalStorage = (tasks: Task[]) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+};
+
+// 読み込み処理
+export const loadTasksFromLocalStorage = (): Task[] | null => {
+  const storedTasks = localStorage.getItem(STORAGE_KEY);
+
+  if (!storedTasks) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(storedTasks) as Task[];
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## 概要
LocalStorageを用いてタスクを保存できるようにしました

## 実装内容
- LocalStorageを用いたタスク保存処理の実装

## 確認したこと
- リロードしても削除したタスクが戻らない
- リロードしても追加したタスクが消えない
- TypeScriptエラーがない

close #9 