### PR TITLE
feat: add basic error handling

### DIFF
--- a/src/components/tasks/TaskForm/TaskEditForm/TaskEditForm.css
+++ b/src/components/tasks/TaskForm/TaskEditForm/TaskEditForm.css
@@ -31,16 +31,17 @@
 
 .task-edit-form__actions {
   display: flex;
-  gap: 8px;
+  justify-content: flex-end;
+  gap: 12px;
   align-items: center;
 }
 
 .task-edit-form__save-button {
   padding: 6px 12px;
   border: none;
-  border-radius: 6px;
-  background-color: #dcfce7;
-  color: #166534;
+  border-radius: 12px;
+  background-color: rgb(127, 255, 191);
+  color: green;
   cursor: pointer;
   font-size: 14px;
 }
@@ -48,9 +49,9 @@
 .task-edit-form__cancel-button {
   padding: 6px 12px;
   border: none;
-  border-radius: 6px;
-  background-color: #e5e7eb;
-  color: #333;
+  border-radius: 12px;
+  background-color: #fee2e2;
+  color: #991b1b;
   cursor: pointer;
   font-size: 14px;
 }
@@ -58,4 +59,11 @@
 .task-edit-form__save-button:hover,
 .task-edit-form__cancel-button:hover {
   opacity: 0.8;
+}
+
+.task-edit-form__error-message {
+  margin: -4px 0 4px;
+  color: #dc2626;
+  font-size: 13px;
+  font-weight: 600;
 }

--- a/src/components/tasks/TaskForm/TaskEditForm/TaskEditForm.tsx
+++ b/src/components/tasks/TaskForm/TaskEditForm/TaskEditForm.tsx
@@ -26,11 +26,15 @@ const TaskEditForm = ({
   const [editDeadline, setEditDeadline] = useState(task.deadline);
   const [editCategory, setEditCategory] = useState<TaskCategory>(task.category);
   const [editPriority, setEditPriority] = useState<TaskPriority>(task.priority);
+  const [errorMessage, setErrorMessage] = useState("");
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (editTitle.trim() === "") {
+    const trimmedTitle = editTitle.trim();
+
+    if (trimmedTitle === "") {
+      setErrorMessage("タスク名を入力してください。");
       return;
     }
 
@@ -52,9 +56,18 @@ const TaskEditForm = ({
           id={`edit-title-${task.id}`}
           type="text"
           value={editTitle}
-          onChange={(e) => setEditTitle(e.target.value)}
+          onChange={(e) => {
+            setEditTitle(e.target.value);
+            if (errorMessage) {
+              setErrorMessage("");
+            }
+          }}
         />
       </div>
+
+      {errorMessage && (
+        <p className="task-edit-form__error-message">{errorMessage}</p>
+      )}
 
        <div className="task-edit-form__field">
         <label htmlFor={`edit-content-${task.id}`}>内容</label>

--- a/src/components/tasks/TaskForm/TaskForm/TaskForm.css
+++ b/src/components/tasks/TaskForm/TaskForm/TaskForm.css
@@ -62,3 +62,12 @@
   transform: translateY(1px);
   box-shadow: 0 2px 6px rgba(37, 99, 235, 0.25);
 }
+.task-form__error-message {
+  margin: -4px 0 4px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background-color: #fee2e2;
+  color: #991b1b;
+  font-size: 13px;
+  font-weight: 600;
+}

--- a/src/components/tasks/TaskForm/TaskForm/TaskForm.tsx
+++ b/src/components/tasks/TaskForm/TaskForm/TaskForm.tsx
@@ -18,6 +18,7 @@ const TaskForm = ({ onAddTask }: TaskFormProps) => {
   const [deadline, setDeadline] = useState("");
   const [category, setCategory] = useState<TaskCategory>("React");
   const [priority, setPriority] = useState<TaskPriority>("medium");
+  const [errorMessage, setErrorMessage] = useState("");
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     // フォーム送信時にページがリロードされるのを防ぐ記述
@@ -25,12 +26,21 @@ const TaskForm = ({ onAddTask }: TaskFormProps) => {
     e.preventDefault();
 
     // 空のタスク名を防ぐ記述
-    // trim()で前後の空白を消去し、それが空文字だった場合にreturnする。
+    // trim()で前後の空白を消去し、それが空文字だった場合にエラーメッセージを出す。
+
+    const trimmedTitle = title.trim();
+
+    if (trimmedTitle === "") {
+      setErrorMessage("タスク名を入力してください");
+      return;
+    }
+
+
     if (title.trim() === "") {
       return;
     }
 
-    onAddTask(title, content, deadline, category, priority);
+    onAddTask(trimmedTitle, content, deadline, category, priority);
 
     // onAddTask後に各stateを初期化する記述
     setTitle("");
@@ -38,6 +48,7 @@ const TaskForm = ({ onAddTask }: TaskFormProps) => {
     setDeadline("");
     setCategory("React");
     setPriority("medium");
+    setErrorMessage("");
   };
 
   return (
@@ -49,10 +60,19 @@ const TaskForm = ({ onAddTask }: TaskFormProps) => {
           id="title"
           type="text"
           value={title}
-          onChange={(e) => setTitle(e.target.value)}
+          onChange={(e) => {
+            setTitle(e.target.value);
+            if (errorMessage) {
+              setErrorMessage("");
+            }
+          }}
           placeholder="例：ReactのuseStateを復習する"
         />
       </div>
+
+      {errorMessage && (
+        <p className="task-edit-form__error-message">{errorMessage}</p>
+      )}
 
       <div className="task-form__field">
         <label htmlFor="context">内容</label>

--- a/src/components/tasks/TaskItem/TaskItem.tsx
+++ b/src/components/tasks/TaskItem/TaskItem.tsx
@@ -87,12 +87,12 @@ const TaskItem = ({
           <span className="task-item__detail-label">
             優先度：
           </span>
-          {priorityLabels[task.priority]}
+          {priorityLabels[task.priority] ?? "中"}
         </span>
       </div>
 
       <div className="task-item__meta">
-        <span className="task-item__deadline">期限: {task.deadline}</span>
+        <span className="task-item__deadline">期限: {task.deadline || "未設定"}</span>
 
         <div className="task-item__actions">
           <button

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,15 +1,53 @@
-import type { Task } from "../types/task";
+import type { Task, TaskCategory, TaskPriority } from "../types/task";
 
 const STORAGE_KEY = "study-task-manager-tasks";
 
-// 保存処理
-// LocalStorageには基本的に文字列しか保存できない
-// JSON.stringify()でタスク配列を文字列に変換して保存している
+const validCategories: TaskCategory[] = [
+  "React",
+  "Django",
+  "Research",
+  "TOEIC",
+  "Other",
+];
+
+const validPriorities: TaskPriority[] = ["low", "medium", "high"];
+
+const isTaskCategory = (value: unknown): value is TaskCategory => {
+  return typeof value === "string" && validCategories.includes(value as TaskCategory);
+};
+
+const isTaskPriority = (value: unknown): value is TaskPriority => {
+  return typeof value === "string" && validPriorities.includes(value as TaskPriority);
+};
+
+const normalizeTask = (task: Partial<Task>): Task | null => {
+  if (
+    typeof task.id !== "string" ||
+    typeof task.title !== "string" ||
+    task.title.trim() === ""
+  ) {
+    return null;
+  }
+
+  return {
+    id: task.id,
+    title: task.title,
+    content: typeof task.content === "string" ? task.content : "",
+    deadline: typeof task.deadline === "string" ? task.deadline : "",
+    category: isTaskCategory(task.category) ? task.category : "Other",
+    priority: isTaskPriority(task.priority) ? task.priority : "medium",
+    completed: typeof task.completed === "boolean" ? task.completed : false,
+    createdAt:
+      typeof task.createdAt === "string"
+        ? task.createdAt
+        : new Date().toISOString(),
+  };
+};
+
 export const saveTasksToLocalStorage = (tasks: Task[]) => {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
 };
 
-// 読み込み処理
 export const loadTasksFromLocalStorage = (): Task[] | null => {
   const storedTasks = localStorage.getItem(STORAGE_KEY);
 
@@ -18,7 +56,17 @@ export const loadTasksFromLocalStorage = (): Task[] | null => {
   }
 
   try {
-    return JSON.parse(storedTasks) as Task[];
+    const parsedTasks: unknown = JSON.parse(storedTasks);
+
+    if (!Array.isArray(parsedTasks)) {
+      return null;
+    }
+
+    const normalizedTasks = parsedTasks
+      .map((task) => normalizeTask(task as Partial<Task>))
+      .filter((task): task is Task => task !== null);
+
+    return normalizedTasks;
   } catch {
     return null;
   }


### PR DESCRIPTION
## 概要
最低限のバリデーションとLocalStorage読み込み時の安全性を高める処理を実装した

## 実装内容
- タスク名が空の場合にエラーメッセージを表示する
- タスク名が空白のみの場合に追加・保存できないようにする
- LocalStorageのJSON parse失敗時に初期データへ戻す
- deadline が未入力の場合の表示を調整する
- category や priority が不正な場合でも画面が壊れないようにする
- エラー表示用のCSSを追加する

## 確認したこと
- 空のタスク名では追加できない
- 空のタスク名で保存できない
- ユーザーに分かる形でエラーメッセージが表示される
- LocalStorageのデータが壊れてもアプリが落ちない
- 期限未入力でも表示が崩れない
- TypeScriptエラーが発生していない


close #35 