### PR TITLE
ui: add state for empty

### DIFF
--- a/src/components/layouts/MainContent/MainContent.tsx
+++ b/src/components/layouts/MainContent/MainContent.tsx
@@ -62,6 +62,57 @@ const MainContent = ({
       return matchesKeyword && matchesCategory && matchesCompletion;
   });
 
+  // const hasNoTasks = tasks.length === 0;
+
+  // const emptyTitle = hasNoTasks
+  //   ? "まだタスクがありません。"
+  //   : "条件に一致するタスクが見つかりませんでした。";
+
+  // const emptyMessage = hasNoTasks
+  //   ? "まずは学習タスクを追加して、今日やることを整理してみましょう。"
+  //   : "検索キーワードやカテゴリ、完了状態の条件を変更してもう一度確認してください。"
+
+  const getEmptyMessage = () => {
+
+    if (tasks.length === 0) {
+      return {
+        title: "まだタスクがありません",
+        message:
+          "まずは学習タスクを追加して、今日やることを整理してみましょう。",
+     };
+    }
+
+    if (normalizedKeyword !== "") {
+      return {
+        title: "検索結果が見つかりませんでした",
+        message:
+          "キーワードを変更するか、検索欄を空にしてもう一度確認してください。",
+      };
+    }
+
+    if (selectedCategory !== "all") {
+      return {
+        title: "このカテゴリのタスクはありません",
+        message:
+          "別のカテゴリを選択するか、新しいタスクを追加してみましょう。",
+      };
+    }
+
+    if (completionFilter !== "all") {
+      return {
+        title: "該当する完了状態のタスクはありません",
+        message: "完了状態の条件を変更してもう一度確認してください。",
+      };
+    }
+
+    return {
+      title: "表示できるタスクがありません",
+      message: "条件を変更してもう一度確認してください。",
+    };
+  };
+
+  const emptyState = getEmptyMessage();
+
   return (
     <main className="main-content">
 
@@ -82,12 +133,14 @@ const MainContent = ({
 
       <TaskList
         tasks={filteredTasks}
+        emptyTitle={emptyState.title}
+        emptyMessage={emptyState.message}
         onToggleTaskCompletion={onToggleTaskCompletion}
         onDeleteTask={onDeleteTask}
         onEditTask={onEditTask}
       />
       
-      <TaskForm onAddTask={onAddTask}/>
+      <TaskForm onAddTask={onAddTask} />
     </main>
   )
 };

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -2,9 +2,12 @@ import "./TaskList.css";
 
 import type { Task, TaskCategory, TaskPriority } from "../../../types/task.ts";
 import TaskItem from "../TaskItem/TaskItem.tsx";
+import EmptyState from "../../ui/EmptyState/EmptyState.tsx";
 
 type TaskListProps = {
   tasks: Task[];
+  emptyTitle: string;
+  emptyMessage: string;
   onToggleTaskCompletion: (id: string) => void;
   onDeleteTask: (id: string) => void;
   onEditTask: (
@@ -17,16 +20,17 @@ type TaskListProps = {
   ) => void;
 };
 
-
 const TaskList = ({
   tasks,
+  emptyTitle,
+  emptyMessage,
   onToggleTaskCompletion,
   onDeleteTask,
   onEditTask,
 }: TaskListProps) => {
   
   if (tasks.length === 0) {
-    return <p className="task-list__empty">表示できるタスクがまだありません。</p>;
+    return <EmptyState title={emptyTitle} message={emptyMessage} />
   }
 
   return (

--- a/src/components/ui/EmptyState/EmptyState.css
+++ b/src/components/ui/EmptyState/EmptyState.css
@@ -1,0 +1,28 @@
+.empty-state {
+  padding: 32px 24px;
+  margin-bottom: 32px;
+
+  border: 1px dashed #cbd5e1;
+  border-radius: 16px;
+  background-color: #ffffff;
+  text-align: center;
+}
+
+.empty-state__icon {
+  margin-bottom: 12px;
+  font-size: 32px;
+}
+
+.empty-state__title {
+  margin: 0 0 8px;
+  font-size: 20px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.empty-state__message {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.7;
+  color: #6b7280;
+}

--- a/src/components/ui/EmptyState/EmptyState.tsx
+++ b/src/components/ui/EmptyState/EmptyState.tsx
@@ -1,0 +1,18 @@
+import "./EmptyState.css";
+
+type EmptyStateProps = {
+  title: string;
+  message: string;
+};
+
+const EmptyState = ({ title, message }: EmptyStateProps) => {
+  return (
+    <div className="empty-state">
+      <div className="empty-state__icon">📝</div>
+      <h3 className="empty-state__title">{title}</h3>
+      <p className="empty-state__message">{message}</p>
+    </div>
+  );
+};
+
+export default EmptyState;


### PR DESCRIPTION
## 概要
空状態のUIを追加した

## 実装内容
- タスクが０件の場合の専用メッセージを表示した
- 検索結果が０件の場合の専用メッセージを表示した
- カテゴリ絞り込み結果が０件の場合の専用メッセージを表示した
- 完了状態フィルター結果が０件の場合の専用メッセージを表示した
- 空状態用のCSSを追加した
- 空状態の管理するための EmptyState コンポーネントを作成した


## 確認したこと
- タスクが０件の場合に自然なメッセージが表示される
- 検索結果が０件の場合に分かりやすいメッセージが表示される
- 絞り込み結果が０件に場合に分かりやすいメッセージが表示される
- 空状態の見た目がアプリ全体のデザインと合っている
- TypeScriptエラーが発生していない

close #36 